### PR TITLE
Include additional files in sdists

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,10 @@
+include LICENSE
+include *.md
+include *.rst
+include requirements*.txt
+
+graft docs
+graft examples
+graft tests
+
+recursive-include pywaffle *.py *.otf


### PR DESCRIPTION
In particular include the license file, which the license requires.  Also include the requirements files, documentation, tests, and additional files in the python source directory.