### PR TITLE
Display labels in the same order as grids when plotting in vertical mode

### DIFF
--- a/pywaffle/waffle.py
+++ b/pywaffle/waffle.py
@@ -605,6 +605,10 @@ class Waffle(Figure):
             if "labels" not in self._pa["legend"] and self._pa["labels"]:
                 self._pa["legend"]["labels"] = self._pa["labels"]
 
+            if self._pa["vertical"] is True:
+                self._pa["legend"]["handles"] = list(reversed(self._pa["legend"]["handles"]))
+                self._pa["legend"]["labels"] = list(reversed(self._pa["legend"]["labels"]))
+
             if "handles" in self._pa["legend"] and "labels" in self._pa["legend"]:
                 self.ax.legend(**self._pa["legend"])
 


### PR DESCRIPTION
This PR changes the order of the legend to match the order of the plotted grids when plotting with `vertical=True`

Before this PR:

![before](https://user-images.githubusercontent.com/1806823/135363604-78f2dfe6-98b6-4303-a895-4af11168495a.png)



After this PR:

![test](https://user-images.githubusercontent.com/1806823/135363610-dbb91758-304f-4835-9923-7db71961b090.png)


Signed-off-by: Alex Couture-Beil <alex@mofo.ca>