### PR TITLE
Bump Font Awesome to v6

### DIFF
--- a/scripts/get_fontawesome.py
+++ b/scripts/get_fontawesome.py
@@ -8,7 +8,7 @@ import json
 import requests
 
 INDENT = " " * 4
-VERSION = "5.15.4"
+VERSION = "6.1.1"
 URI = "https://raw.githubusercontent.com/FortAwesome/Font-Awesome/master/metadata/icons.json"
 
 


### PR DESCRIPTION
Hi there! Firstly, just wanted to say I absolutely love this package - it works so seamlessly, and you've really thought of everything in terms of how people might want to tweak things to make some beautiful visualisations!

I noticed that Font Awesome released v6 (in Feb 2022) which have quite a few new icons, so I thought I'd bump the version to their latest. Do let me know if it's not just a matter of bumping the version here!